### PR TITLE
Changes for claws_fcm

### DIFF
--- a/src/claws_fcm.erl
+++ b/src/claws_fcm.erl
@@ -1,6 +1,6 @@
 %%%-------------------------------------------------------------------
 %%% @author yan.guiborat
-%%% @copyright (C) 2018, <COMPANY>
+%%% @copyright (C) 2018
 %%% @doc
 %%%
 %%% @end
@@ -9,73 +9,19 @@
 -module(claws_fcm).
 -author("yan.guiborat").
 
--behaviour(gen_server).
-
-%% API
--include_lib("ibrowse/include/ibrowse.hrl").
--include("snatch.hrl").
+-behaviour(claws).
 
 -export([start_link/2,
-  stop/0]).
+         stop/0,
+         send/2,
+         send/3]).
 
--export([init/1,
-  handle_info/2,
-  handle_cast/2,
-  handle_call/3,
-  code_change/3,
-  terminate/2]).
-
--export([send/2]).
-
--define(SERVER, ?MODULE).
-
--record(state, {
-  poolpid :: pid() | undefined
-  }).
-
-%%%===================================================================
-%%% API
-%%%===================================================================
-
-%%--------------------------------------------------------------------
-%% @doc
-%% Starts the server
-%%
-%% @end
-%%--------------------------------------------------------------------
 -spec(start_link(FCMConfig :: map(), NbWorkers :: integer()) ->
   {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
 start_link(FCMConfig, NbWorkers) ->
   application:start(pooler),
   application:start(fxml),
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [FCMConfig, NbWorkers], []).
-
-
-
-stop() ->
-  gen_server:stop(?MODULE).
-
-
-%%%===================================================================
-%%% gen_server callbacks
-%%%===================================================================
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Initializes the server
-%%
-%% @spec init(Args) -> {ok, State} |
-%%                     {ok, State, Timeout} |
-%%                     ignore |
-%%                     {stop, Reason}
-%% @end
-%%--------------------------------------------------------------------
--spec(init(Args :: term()) ->
-  {ok, State :: #state{}} | {ok, State :: #state{}, timeout() | hibernate} |
-  {stop, Reason :: term()} | ignore).
-init([FCMConfig, NbWorkers]) ->
-  io:format("~nStarting pool claw with params :~p",[{FCMConfig, NbWorkers}]),
+  error_logger:info_msg("~nStarting pool claw with params :~p", [{FCMConfig, NbWorkers}]),
   PoolSpec = [
     {name, push_pool},
     {worker_module, claws_fcm_worker},
@@ -88,96 +34,15 @@ init([FCMConfig, NbWorkers]) ->
     {fcm_conf, FCMConfig}
   ],
   pooler:new_pool(PoolSpec),
-  {ok, #state{}}.
+  {ok, whereis(push_pool)}.
 
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling call messages
-%%
-%% @end
-%%--------------------------------------------------------------------
--spec(handle_call(Request :: term(), From :: {pid(), Tag :: term()},
-    State :: #state{}) ->
-  {reply, Reply :: term(), NewState :: #state{}} |
-  {reply, Reply :: term(), NewState :: #state{}, timeout() | hibernate} |
-  {noreply, NewState :: #state{}} |
-  {noreply, NewState :: #state{}, timeout() | hibernate} |
-  {stop, Reason :: term(), Reply :: term(), NewState :: #state{}} |
-  {stop, Reason :: term(), NewState :: #state{}}).
-handle_call(_Request, _From, State) ->
-  {reply, ok, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling cast messages
-%%
-%% @end
-%%--------------------------------------------------------------------
--spec(handle_cast(Request :: term(), State :: #state{}) ->
-  {noreply, NewState :: #state{}} |
-  {noreply, NewState :: #state{}, timeout() | hibernate} |
-  {stop, Reason :: term(), NewState :: #state{}}).
-handle_cast(_Request, State) ->
-  {noreply, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling all non call/cast messages
-%%
-%% @spec handle_info(Info, State) -> {noreply, State} |
-%%                                   {noreply, State, Timeout} |
-%%                                   {stop, Reason, State}
-%% @end
-%%--------------------------------------------------------------------
--spec(handle_info(Info :: timeout() | term(), State :: #state{}) ->
-  {noreply, NewState :: #state{}} |
-  {noreply, NewState :: #state{}, timeout() | hibernate} |
-  {stop, Reason :: term(), NewState :: #state{}}).
-handle_info(_Info, State) ->
-  {noreply, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% This function is called by a gen_server when it is about to
-%% terminate. It should be the opposite of Module:init/1 and do any
-%% necessary cleaning up. When it returns, the gen_server terminates
-%% with Reason. The return value is ignored.
-%%
-%% @spec terminate(Reason, State) -> void()
-%% @end
-%%--------------------------------------------------------------------
--spec(terminate(Reason :: (normal | shutdown | {shutdown, term()} | term()),
-    State :: #state{}) -> term()).
-terminate(_Reason, _State) ->
-  ok.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Convert process state when code is changed
-%%
-%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
-%% @end
-%%--------------------------------------------------------------------
--spec(code_change(OldVsn :: term() | {down, term()}, State :: #state{},
-    Extra :: term()) ->
-  {ok, NewState :: #state{}} | {error, Reason :: term()}).
-code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
-
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
+stop() ->
+  gen_server:stop(?MODULE).
 
 send(Data, To) ->
   P = pooler:take_member(push_pool),
   gen_statem:cast(P, {send, To, Data}),
   pooler:return_member(push_pool, P, ok).
 
-
-
+send(Data, To, _ID) ->
+  send(Data, To).

--- a/src/claws_fcm_worker.erl
+++ b/src/claws_fcm_worker.erl
@@ -1,6 +1,5 @@
 -module(claws_fcm_worker).
 -behaviour(gen_statem).
--behaviour(claws).
 
 -include_lib("fast_xml/include/fxml.hrl").
 -include("snatch.hrl").
@@ -55,7 +54,7 @@ start_link(FCMParams) ->
   gen_statem:start_link(?MODULE, [FCMParams], []).
 
 init([#{gcs_add := Gcs_add, gcs_port := Gcs_Port, server_id := ServerId, server_key := ServerKey}]) ->
-  io:format("~nStarting FCM claw :~p", [#{gcs_add => Gcs_add, gcs_port => Gcs_Port, server_id => ServerId, server_key => ServerKey}]),
+  error_logger:info_msg("~nStarting FCM claw :~p", [#{gcs_add => Gcs_add, gcs_port => Gcs_Port, server_id => ServerId, server_key => ServerKey}]),
   {ok, disconnected, #data{gcs_add = Gcs_add, gcs_port = Gcs_Port, server_id = ServerId, server_key = ServerKey}, [{next_event, cast, connect}]}.
 
 callback_mode() -> handle_event_function.
@@ -139,28 +138,28 @@ wait_for_result(info, {ssl, _SSLSock, _Message},  Data) ->
 
 
 binding(info, {ssl, _SSLSock, _Message}, Data) ->
-  io:format("~nbinding Reeceived :~p",[_Message]),
-  io:format("~nClaw is connected",[]),
+  error_logger:info_msg("~nbinding Reeceived :~p",[_Message]),
+  error_logger:info_msg("~nClaw is connected",[]),
   snatch:connected(claws_fcm),
   {next_state, binded, Data, []}.
 
 binded(cast, {send, To, Payload}, #data{socket = Socket}) ->
-  io:format("~nReceived payload :~p",[Payload]),
+  error_logger:info_msg("~nReceived payload :~p",[Payload]),
 
   JSONPayload = lists:foldl(
     fun({Key,Value},Acc) -> maps:put(Key, Value,Acc) end,#{<<"message_id">> => base64:encode(crypto:strong_rand_bytes(6)), <<"to">> => To},Payload),
 
   FinalPayload = {xmlcdata, jsone:encode(JSONPayload)},
 
-  io:format("~nSending payload :~p",[FinalPayload]),
+  error_logger:info_msg("~nSending payload :~p",[FinalPayload]),
   Gcm = {xmlel, <<"gcm">>, [{<<"xmlns">>, <<"google:mobile:data">>}], [FinalPayload]},
   Mes = {xmlel, <<"message">>, [{<<"id">>, base64:encode(crypto:strong_rand_bytes(6))}], [Gcm]},
-  io:format("~nSending push :~p",[Mes]),
+  error_logger:info_msg("~nSending push :~p",[Mes]),
   ssl:send(Socket, fxml:element_to_binary(Mes)),
   {keep_state_and_data, []};
 
 binded(cast, {received, #xmlel{} = Packet}, _Data) ->
-  io:format("~npuscomp received ~p",[Packet]),
+  error_logger:info_msg("~npuscomp received ~p",[Packet]),
   From = snatch_xml:get_attr(<<"from">>, Packet),
   To = snatch_xml:get_attr(<<"to">>, Packet),
   Via = #via{jid = From, exchange = To, claws = ?MODULE},
@@ -168,13 +167,13 @@ binded(cast, {received, #xmlel{} = Packet}, _Data) ->
   {keep_state_and_data, []};
 
 binded(info, {ssl, _SSLSock, <<" ">>}, _Data) ->
-  io:format("~nKEEP ALIVE", []),
+  error_logger:info_msg("~nKEEP ALIVE", []),
   {keep_state_and_data, []};
 
 
 binded(info, {ssl, _SSLSock, Message}, Data) ->
   DecPak = fxml_stream:parse_element(Message),
-  io:format("~npuscomp received SSL ~p on socket ~p",[DecPak, _SSLSock]),
+  error_logger:info_msg("~npuscomp received SSL ~p on socket ~p", [DecPak, _SSLSock]),
   case DecPak#xmlel.name of
     <<"message">> ->
       case process_fcm_message(DecPak, Data) of
@@ -190,22 +189,16 @@ binded(info, {ssl, _SSLSock, Message}, Data) ->
       {keep_state_and_data, []}
   end;
 
-
-binded(info, {ssl, _SSLSock, Message}, _Data) ->
-  io:format("~npuscomp received SSL ~p",[Message]),
-  snatch:received(Message),
-  {keep_state_and_data, []};
-
 binded(cast, _Unknown, _Data) ->
   {keep_state_and_data, []}.
 
 
 drainned(_, {ssl, _SSLSock, Message}, Data) ->
-  io:format("~nFCM claw received SSL ~p in state drainned",[Message]),
+  error_logger:info_msg("~nFCM claw received SSL ~p in state drainned", [Message]),
   {stop, normal, Data};
 
 drainned(_, Msg, _Data) ->
-  io:format("~nFCM claw received ~p in state drainned",[Msg]),
+  error_logger:info_msg("~nFCM claw received ~p in state drainned", [Msg]),
   {keep_state_and_data, []}.
 
 
@@ -255,40 +248,40 @@ process_fcm_message(Message, Data) ->
   Message_type = proplists:get_value(<<"type">>, Message#xmlel.attrs),
   case Message_type of
     <<"error">> ->
-      io:format("~nFCM claw received error from FCM server :~p",[Message]),
+      error_logger:info_msg("~nFCM claw received error from FCM server :~p", [Message]),
       ok;
     _ ->
-      io:format("~nFCM claw received message from google FCM :~p",[{Message, Data}]),
-      process_message_payload(lists:nth(1,Message#xmlel.children))
+      error_logger:info_msg("~nFCM claw received message from google FCM :~p", [{Message, Data}]),
+      process_message_payload(hd(Message#xmlel.children))
   end.
 
 
 process_message_payload(#xmlel{name = <<"data:gcm">>} = Data) ->
-  io:format("~nprocessing payloadd : ~p",[Data]),
+  error_logger:info_msg("~nprocessing payloadd : ~p", [Data]),
   Cdata = fxml:get_tag_cdata(Data),
   Payload = jsone:decode(Cdata),
   process_json_payload(Payload);
 
 
 process_message_payload(El) ->
-  io:format("Received unmanaged payload from Google FCM : ~p",[El]),
+  error_logger:info_msg("Received unmanaged payload from Google FCM : ~p", [El]),
   ok.
 
 
 process_json_payload(#{<<"message_type">> := <<"control">>, <<"control_type">> := <<"CONNECTION_DRAINING">>}) ->
-  io:format("~nFCm claw, connection drainned",[]),
+  error_logger:info_msg("~nFCm claw, connection drainned",[]),
   pooler:remove_pid(self()),
   {next_state, drainned};
 
 process_json_payload(#{<<"message_type">> := <<"ack">>}) ->
-  io:format("~nACk from FCM",[]),
+  error_logger:info_msg("~nACk from FCM",[]),
   ok;
 
 process_json_payload(#{<<"message_type">> := <<"nack">>}) ->
-  io:format("~nNACk from FCM",[]),
+  error_logger:info_msg("~nNACk from FCM",[]),
   ok;
 
 
 process_json_payload(Unk) ->
-  io:format("~nClaw FCM received unmanaged payload :~p",[Unk]),
+  error_logger:info_msg("~nClaw FCM received unmanaged payload :~p", [Unk]),
   ok.

--- a/src/claws_kafka.erl
+++ b/src/claws_kafka.erl
@@ -77,7 +77,7 @@ handle_cast({received, #kafka_message{key = _Key, value = XML}, _Partition},
             #{trimmed := true} = Opts) ->
     case fxml_stream:parse_element(XML) of
         {error, _Error} ->
-            io:format("error => ~p~n", [_Error]);
+            error_logger:error_msg("error => ~p~n", [_Error]);
         Packet ->
             From = snatch_xml:get_attr(<<"from">>, Packet),
             To = snatch_xml:get_attr(<<"to">>, Packet),
@@ -91,7 +91,7 @@ handle_cast({received, #kafka_message{key = _Key, value = XML}, _Partition},
             Opts) ->
     case fxml_stream:parse_element(XML) of
         {error, _Error} ->
-            io:format("error => ~p~n", [_Error]);
+            error_logger:error_msg("error => ~p~n", [_Error]);
         Packet ->
             From = snatch_xml:get_attr(<<"from">>, Packet),
             To = snatch_xml:get_attr(<<"to">>, Packet),


### PR DESCRIPTION
Hi, @netboz check the changes suggested in this PR. The main aspects are:

- don't create a gen_server unless you have to do something with it.
- use error_logger:info_msg or error_logger:error_msg instead of io:format

Keep in mind `io` is a service for Erlang and it's more overwhelmed with the load than error_logger. It could be a blind limitation.